### PR TITLE
Fix settings uri

### DIFF
--- a/src/auto_reconnect.user.js
+++ b/src/auto_reconnect.user.js
@@ -67,7 +67,7 @@ function embedStyle() {
 }
 
 function createMenu() {
-  return $('<div id="ar-bar" class="settingsMenu__item settingsMenu__item__autoreconnect"><a class="settingsMenu__link" href="#?/settings=autoreconnect">Auto Reconnect</a></div>').insertAfter('.settingsContainer .settingsMenu .settingsMenu__item:last');
+  return $('<div id="ar-bar" class="settingsMenu__item settingsMenu__item__autoreconnect"><a class="settingsMenu__link" href="/?/settings=autoreconnect">Auto Reconnect</a></div>').insertAfter('.settingsContainer .settingsMenu .settingsMenu__item:last');
 }
 
 function createContainer() {


### PR DESCRIPTION
Settings URI does not fix to root `/`.

Meaning instead of getting URI `https://www.irccloud.com/?/settings=autoreconnect` 👍 (does work)

I would get URI `https://www.irccloud.com/?/settings=design#?/settings=autoreconnect` 👎 (does not work)

Please verify and merge at your own behest. ;-)